### PR TITLE
Fix boot_partition RPC argument handling and prevent backend crash caused by json(req)

### DIFF
--- a/htdocs/luci-static/resources/view/system/advanced-reboot.js
+++ b/htdocs/luci-static/resources/view/system/advanced-reboot.js
@@ -259,7 +259,7 @@ return view.extend({
 								{
 									class: "btn cbi-button cbi-button-positive important",
 									click: L.bind(function () {
-										this.callBootPartition({ number: String(pn) })
+										this.callBootPartition(String(pn))
 											.then(
 												L.bind(function (res) {
 													ui.hideModal();


### PR DESCRIPTION
This PR fixes two issues affecting the luci.advanced-reboot workflow:
1. Front-end RPC argument was never delivered to backend, causing boot_partition to always receive {} instead of the expected { "number": "1" }.
2. Backend crashed when logging json(req), due to circular references inside the ubus request object.
Both issues prevented the dual‑partition switching logic from working correctly.

## Frontend Fix
### Problem
The original code used: `this.callBootPartition({ number: String(pn) });`
But the RPC declaration was:
```
callBootPartition: rpc.declare({
    object: "luci.advanced-reboot",
    method: "boot_partition",
    expect: {},
}),
```
Without a params declaration, rpc.declare() ignores all arguments and always sends: `{}`
This resulted in the backend receiving: `"params": [ "...", "luci.advanced-reboot", "boot_partition", {} ]`

#### Fix
Declare the expected parameter:
```
callBootPartition: rpc.declare({
    object: "luci.advanced-reboot",
    method: "boot_partition",
    params: ["number"],
    expect: {},
});
```
And update the call site to pass a primitive instead of an object: `this.callBootPartition(String(pn));`

## Backend Fix
### Problem
`log("boot_partition req=" + json(req));` caused the backend to crash.
#### Fix
Remove this line.