### PR TITLE
Fix string formatting for device name in advanced-reboot.js

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/openwrt-release.yml
+++ b/.github/workflows/openwrt-release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install ucode build dependencies
         run: |
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: 🧾 Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 📛 Set PKG_NAME from repo
         run: echo "PKG_NAME=${{ github.event.repository.name }}" >> "$GITHUB_ENV"
@@ -194,7 +194,7 @@ jobs:
 
     steps:
       - name: 🧾 Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 🔍 Extract version and release from Makefile
         id: version

--- a/htdocs/luci-static/resources/view/system/advanced-reboot.js
+++ b/htdocs/luci-static/resources/view/system/advanced-reboot.js
@@ -429,7 +429,7 @@ return view.extend({
 			}
 		}
 
-		body.appendChild(E("h3", _("%s Partitions", (device_name || ""))));
+		body.appendChild(E("h3", _("%s Partitions").format(device_name || "")));
 
 		if (
 			device_info &&


### PR DESCRIPTION
`(Device_name || "")` is passed in as the second parameter, which is directly ignored by the _() function, so the browser renders the unformatted "%s Partitions" as it is.

<img width="1217" height="338" alt="Screenshot 2026-06-21 at 07 10 53" src="https://github.com/user-attachments/assets/0645353f-3c3e-4842-a1ab-dba6d1a7d9d3" />
